### PR TITLE
Added useMapBackgroundColor property to TiledScene

### DIFF
--- a/src/tiledscene.h
+++ b/src/tiledscene.h
@@ -43,7 +43,8 @@ class TiledScene : public Scene
     Q_OBJECT
 
     Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged)
-    Q_PROPERTY(QQuickItem *background READ background WRITE setBackground NOTIFY backgroundChanged)
+    Q_PROPERTY(QQuickItem *backgroundItem READ backgroundItem WRITE setBackgroundItem NOTIFY backgroundItemChanged)
+    Q_PROPERTY(bool useMapBackgroundColor READ useMapBackgroundColor WRITE setUseMapBackgroundColor NOTIFY useMapBackgroundColorChanged)
     Q_PROPERTY(QQmlListProperty<TiledLayer> layers READ layers)
 public:
     TiledScene(Game *parent = 0);
@@ -51,8 +52,11 @@ public:
     QUrl source() const;
     void setSource(const QUrl &source);
 
-    QQuickItem *background() const;
-    void setBackground(QQuickItem *);
+    QQuickItem *backgroundItem() const;
+    void setBackgroundItem(QQuickItem *);
+
+    bool useMapBackgroundColor() const;
+    void setUseMapBackgroundColor(bool);
 
     QQmlListProperty<TiledLayer> layers();
 
@@ -66,14 +70,16 @@ public:
     virtual void componentComplete();
 signals:
     void sourceChanged();
-    void backgroundChanged();
+    void backgroundItemChanged();
+    void useMapBackgroundColorChanged();
 protected:
     QSGNode *updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *);
     virtual void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;
 private:
     TMXMap *m_map;
     QUrl m_source;
-    QQuickItem *m_background;
+    QQuickItem *m_backgroundItem;
+    bool m_useMapBackgroundColor;
     QPixmap m_image;
     QList<TiledLayer *> m_layers;
 

--- a/src/tmx/tmxmap.h
+++ b/src/tmx/tmxmap.h
@@ -58,6 +58,8 @@ public:
     int tileHeight() const { return m_tiledMap->tileHeight(); }
     QSize tileSize() const { return m_tiledMap->tileSize(); }
 
+    QColor backgroundColor() const { return m_tiledMap->backgroundColor(); }
+
     QList<TMXLayer> layers() const {
         QList<TMXLayer> allLayers;
         foreach(Tiled::Layer *layer, m_tiledMap->layers())


### PR DESCRIPTION
- Renamed "background" property to "backgroundItem" to avoid ambiguity
- Added useMapBackgroundColor property to TiledScene, allowing the user
to specify if he wants to use the background color specified in the TMX
file