### PR TITLE
Minor cleanup before beginning Android support

### DIFF
--- a/src/bacon2dimagelayer.cpp
+++ b/src/bacon2dimagelayer.cpp
@@ -224,7 +224,7 @@ QSGNode *Bacon2DImageLayer::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeDat
 
     if (boundingRect().isEmpty()) {
         delete n;
-        return 0;
+        return nullptr;
     }
 
     if (!n) {

--- a/src/bacon2dlayer.cpp
+++ b/src/bacon2dlayer.cpp
@@ -152,8 +152,7 @@ void Bacon2DLayer::update(const int &delta)
 
 void Bacon2DLayer::updateEntities(const int &delta)
 {
-    QQuickItem *item;
-    foreach (item, childItems()) {
+    for (QQuickItem *item : childItems()) {
         if (Entity *entity = qobject_cast<Entity *>(item))
             entity->update(delta);
     }

--- a/src/game.h
+++ b/src/game.h
@@ -31,10 +31,10 @@
 
 #include "enums.h"
 
-#include <QtQuick/QQuickItem>
-#include <QtCore/QTime>
-#include <QtCore/QtGlobal>
-#include <QtCore/QStack>
+#include <QQuickItem>
+#include <QTime>
+#include <QtGlobal>
+#include <QStack>
 
 class Scene;
 class Viewport;
@@ -53,7 +53,7 @@ class Game : public QQuickItem
     Q_PROPERTY(int stackLevel READ stackLevel NOTIFY stackLevelChanged)
 public:
     Game(QQuickItem *parent = nullptr);
-    virtual ~Game();
+    virtual ~Game() override = default;
 
     Scene *currentScene() const;
     void setCurrentScene(Scene *currentScene);

--- a/src/layerscrollbehavior.cpp
+++ b/src/layerscrollbehavior.cpp
@@ -32,10 +32,9 @@ LayerScrollBehavior::LayerScrollBehavior(QObject *parent)
 
 void LayerScrollBehavior::update(const int &delta)
 {
-    Q_UNUSED(delta);
+    Q_UNUSED(delta)
 
-    QQuickItem *child;
-    foreach (child, m_target->childItems()) {
+    for (QQuickItem *child : m_target->childItems()) {
         if (QQuickItem *item = dynamic_cast<QQuickItem*>(child)) {
             item->setX(item->x() + m_horizontalStep);
             item->setY(item->y() + m_verticalStep);

--- a/src/private/entityfactory.cpp
+++ b/src/private/entityfactory.cpp
@@ -106,6 +106,12 @@ Entity *EntityFactory::createEntity(const QVariant &item, Scene *parentScene, QQ
             return nullptr;
         }
 
+        if (m_entityMap.contains(entity->entityId())) {
+            qWarning() << "EntityFactory: Entity already exists.";
+            entity->deleteLater();
+            return nullptr;
+        }
+
         return addEntity(entity);
     } else if (item.type() == QVariant::String) {
         const QUrl source = QQmlEngine::contextForObject(parentScene)->resolvedUrl(QUrl(item.toString()));
@@ -123,6 +129,12 @@ Entity *EntityFactory::createEntity(const QVariant &item, Scene *parentScene, QQ
         if (!entity) {
             qWarning() << "EntityFactory: Component must inherit Entity.";
             incubator.object()->deleteLater();
+            return nullptr;
+        }
+
+        if (m_entityMap.contains(entity->entityId())) {
+            qWarning() << "EntityFactory: Entity already exists.";
+            entity->deleteLater();
             return nullptr;
         }
 
@@ -154,6 +166,12 @@ Entity *EntityFactory::createEntity(const QVariant &item, Scene *parentScene, QQ
         entity->setProperty("__TiledObjectGroup__id", entityComponent->mapObject().id());
         entity->setProperty("__TiledObjectGroup__properties", entityComponent->mapObject().properties());
 
+        if (m_entityMap.contains(entity->entityId())) {
+            qWarning() << "EntityFactory: Entity already exists.";
+            entity->deleteLater();
+            return nullptr;
+        }
+
         return addEntity(entity);
     }
 
@@ -164,11 +182,6 @@ Entity *EntityFactory::addEntity(Entity *entity)
 {
     if (!entity) {
         qWarning() << "EntityFactory: Entity is null.";
-        return nullptr;
-    }
-    if (m_entityMap.contains(entity->entityId())) {
-        qWarning() << "EntityFactory: Entity already exists.";
-        entity->deleteLater();
         return nullptr;
     }
 

--- a/src/private/entityfactory.h
+++ b/src/private/entityfactory.h
@@ -18,7 +18,7 @@ public:
 
     Entity *createEntity(const QVariant &, Scene *parentScene, QQmlEngine *engine);
     Entity *addEntity(Entity *entity);
-    Entity *findEntity(const QString &entityType, const QVariantMap &properties);
+    Entity *findEntity(const QString &entityType, const QVariantMap &properties = QVariantMap());
     Entity *getEntity(const QString &entityId);
     QList<Entity *> getEntities(const QString &entityType);
     void destroyEntity(const QString &entityId);

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -27,17 +27,15 @@
  */
 
 #include "scene.h"
-
 #include "game.h"
 #include "bacon2dlayer.h"
 #include "viewport.h"
+#include "box2dbody.h"
 
-#include <QtCore/QtGlobal>
-#include <QtQml/QQmlEngine>
+#include <QtGlobal>
+#include <QQmlEngine>
 #include <QQmlContext>
 #include <QQmlApplicationEngine>
-
-#include "../../3rdparty/qml-box2d/box2dbody.h"
 
 /*!
   \qmltype Scene
@@ -487,8 +485,7 @@ void Scene::rayCast(Box2DRayCast *rayCast, const QPointF &point1, const QPointF 
 
 void Scene::initializeEntities(QQuickItem *parent)
 {
-    QQuickItem *child;
-    foreach (child, parent->childItems()) {
+    for (QQuickItem *child : parent->childItems()) {
         if (Entity *entity = dynamic_cast<Entity *>(child)) {
             entity->setScene(this);
         } else if (Bacon2DLayer *layer = dynamic_cast<Bacon2DLayer *>(child)) {
@@ -496,7 +493,7 @@ void Scene::initializeEntities(QQuickItem *parent)
         }
 
         if (m_physics && m_world) {
-            foreach (Box2DBody *body, child->findChildren<Box2DBody *>(QString(), Qt::FindDirectChildrenOnly)) {
+            for (Box2DBody *body : child->findChildren<Box2DBody *>(QString(), Qt::FindDirectChildrenOnly)) {
                 body->setWorld(m_world);
             }
         }
@@ -538,7 +535,7 @@ void Scene::itemChange(ItemChange change, const ItemChangeData &data)
         }
 
         if (m_physics && m_world) {
-            foreach (Box2DBody *body, child->findChildren<Box2DBody *>(QString(), Qt::FindDirectChildrenOnly)) {
+            for (Box2DBody *body : child->findChildren<Box2DBody *>(QString(), Qt::FindDirectChildrenOnly)) {
                 body->setWorld(m_world);
             }
         }

--- a/src/scene.h
+++ b/src/scene.h
@@ -34,10 +34,10 @@
 #include "box2dworld.h"
 #include "box2ddebugdraw.h"
 
-#include <QtCore/QtGlobal>
+#include <QtGlobal>
 
-#include <QtQml/QQmlComponent>
-#include <QtQuick/QQuickItem>
+#include <QQmlComponent>
+#include <QQuickItem>
 
 class Game;
 class Viewport;

--- a/src/spritesheetgrid.cpp
+++ b/src/spritesheetgrid.cpp
@@ -83,6 +83,16 @@ qreal SpriteSheetGrid::height() const
     return m_height;
 }
 
+qreal SpriteSheetGrid::implicitWidth() const
+{
+    return m_implicitWidth;
+}
+
+qreal SpriteSheetGrid::implicitHeight() const
+{
+    return m_implicitHeight;
+}
+
 int SpriteSheetGrid::horizontalFrameCount() const
 {
     return m_horizontalFrameCount;

--- a/src/spritestrip.cpp
+++ b/src/spritestrip.cpp
@@ -21,6 +21,20 @@ SpriteStrip::SpriteStrip(QQuickItem *parent)
 {
 }
 
+QString SpriteStrip::name() const
+{
+    return m_name;
+}
+
+void SpriteStrip::setName(const QString &name)
+{
+    if (m_name == name)
+        return;
+
+    m_name = name;
+    emit nameChanged();
+}
+
 int SpriteStrip::frame() const
 {
     return m_frame;

--- a/src/src.pro
+++ b/src/src.pro
@@ -6,14 +6,14 @@ QMAKE_HOST_ARCH=$$QMAKE_HOST.arch
      CONFIG += cross_build
 }
 
-CONFIG += c++11
+CONFIG += c++17
 
 QT += quick
 
 TARGET = bacon2dplugin
 TARGETPATH = Bacon2D
-
 API_VER=1.0
+
 DESTDIR = $$OUT_PWD/qml/Bacon2D
 
 OBJECTS_DIR = tmp
@@ -26,13 +26,11 @@ INCLUDEPATH += ../3rdparty/qml-box2d/
 INCLUDEPATH += ../3rdparty/tiled/src/
 
 DEFINES += STATIC_PLUGIN_BOX2D
+win32:DEFINES += WIN32
+
 include(../3rdparty/qml-box2d/box2d-static.pri)
-
-
 include(../3rdparty/tiled/src/libtiled/libtiled-static.pri)
 include($$PWD/tmx/tmx.pri)
-
-win32:DEFINES += WIN32
 
 HEADERS += \
     enums.h \
@@ -100,10 +98,6 @@ SOURCES += \
     private/entityfactory.cpp \
     tiledobjectgroup.cpp
 
-!isEmpty(QTPATH): target.path = $$QTPATH/qml/$$TARGETPATH
-else: target.path = $$[QT_INSTALL_QML]/$$replace(TARGETPATH, \\., /).$$API_VER
-;
-
 QMLFILES += \
             $$PWD/InfiniteScrollEntity.qml \
             $$PWD/BoxBody.qml \
@@ -132,14 +126,22 @@ unix {
     }
 }
 
-qmltypes.path = $$target.path
+target.path = $$[QT_INSTALL_QML]/$$replace(TARGETPATH, \\., /).$$API_VER
+target.files = $${QMLFILES}
+
+qmltypes.path = $${target.path}
 qmltypes.files += $$DESTDIR/plugins.qmltypes
 export(qmltypes.files)
 
-qmlpluginfiles.path = $$target.path
-qmlpluginfiles.files = $$QMLFILES
+QML2_IMPORT_PATH = $$OUT_PWD/qml
 
-QMAKE_EXTRA_TARGETS += qmltypes qmlpluginfiles
-INSTALLS += target qmltypes qmlpluginfiles
+QMAKE_EXTRA_TARGETS += qmltypes
 
-DISTFILES +=
+!android {
+    qmlpluginfiles.path = $${target.path}
+    qmlpluginfiles.files = $$QMLFILES
+    QMAKE_EXTRA_TARGETS += qmlpluginfiles
+    INSTALLS += qmlpluginfiles
+}
+
+INSTALLS += target qmltypes

--- a/src/tiledobjectgroup.cpp
+++ b/src/tiledobjectgroup.cpp
@@ -409,7 +409,7 @@ void TiledObjectGroup::setCount(int count)
 }
 
 /*!
-  \qmlmethod string TiledObjectGroup::getProperty(string name, variant defaultValue)
+  \qmlmethod string TiledObjectGroup::getProperty(string entityId, string name, variant defaultValue)
   \brief This method returns the value of the custom property called \e name for this TMX object.
   If the value is not provided, the \e defaultValue is used instead.
 
@@ -464,6 +464,8 @@ QVariantList TiledObjectGroup::createdEntities() const
 
 void TiledObjectGroup::initialize()
 {
+    if (!m_active)
+        return;
     if (!m_entities.isEmpty())
         deinitialize();
 

--- a/src/tiledscene.cpp
+++ b/src/tiledscene.cpp
@@ -364,7 +364,7 @@ QQmlListProperty<TiledLayer> TiledScene::layers()
                                         nullptr);
 }
 
-QVariant TiledScene::getProperty(const QString &name, const QVariant &defaultValue) const
+QVariant TiledScene::getMapProperty(const QString &name, const QVariant &defaultValue) const
 {
     if (m_map)
         return m_map->properties().value(name, defaultValue);

--- a/src/tiledscene.h
+++ b/src/tiledscene.h
@@ -64,7 +64,7 @@ public:
 
     QQmlListProperty<TiledLayer> layers();
 
-    Q_INVOKABLE QVariant getProperty(const QString &name, const QVariant &defaultValue = QVariant()) const;
+    Q_INVOKABLE QVariant getMapProperty(const QString &name, const QVariant &defaultValue = QVariant()) const;
 
     TMXMap *tiledMap() const { return m_map; }
 signals:


### PR DESCRIPTION
- Remove code smell from EntityFactory::addEntity(); function should not
call QObject::deleteLater()
- Add default parameter to EntityFactory::findEntity()
- Replace all Qt "foreach" with enhanced "for" loops
- Remove extraneous information from headers
- Add name to SpriteStrip
- Up C++ version to C++17
- Add "entityId" property to TiledObjectGroup::getProperty()
- Change TiledScene::getProperty() to TiledScene::getMapProperty() for
clarity
- Change "0" to "nullptr" for null pointers