### PR TITLE
Add SceneAnchorItem

### DIFF
--- a/examples/tiledscene/main.qml
+++ b/examples/tiledscene/main.qml
@@ -34,10 +34,13 @@ Game {
         Keys.forwardTo: actor.getEntity()
 
         VirtualJoystick {
-            x: scene.viewport.x
-            y: -scene.viewport.y
+            anchors {
+                left: scene.anchorItem.left
+                top: scene.anchorItem.top
+                bottom: scene.anchorItem.bottom
+            }
+
             width: scene.viewport.width / 2
-            height: scene.viewport.height
             keyNavigation: VirtualJoystickKeyNavigation { }
         }
 

--- a/src/private/plugins.cpp
+++ b/src/private/plugins.cpp
@@ -90,6 +90,7 @@ void Plugins::registerTypes(const char *uri)
     // Bacon2D
     qmlRegisterType<Game>("Bacon2D", 1, 0, "Game");
     qmlRegisterType<Scene>("Bacon2D", 1, 0, "Scene");
+    qmlRegisterType<SceneAnchorItem>();
     qmlRegisterType<Entity>("Bacon2D", 1, 0, "Entity");
     qmlRegisterType<PhysicsEntity>("Bacon2D", 1, 0, "PhysicsEntity");
     qmlRegisterType<Sprite>("Bacon2D", 1, 0, "Sprite");

--- a/src/scene.h
+++ b/src/scene.h
@@ -42,6 +42,19 @@
 class Game;
 class Viewport;
 
+class SceneAnchorItem : public QQuickItem
+{
+    Q_OBJECT
+public:
+    explicit SceneAnchorItem(QQuickItem *parent = nullptr);
+    void setViewport(Viewport *viewport);
+private:
+    void bindToViewport(Viewport *viewport);
+    void bindToParentScene();
+private:
+    Viewport *m_viewport;
+};
+
 class Scene : public QQuickItem
 {
     Q_OBJECT
@@ -62,6 +75,7 @@ class Scene : public QQuickItem
     /* End Box2DWorld wrapped properties */
     Q_PROPERTY(QObject *enterAnimation READ enterAnimation WRITE setEnterAnimation NOTIFY enterAnimationChanged)
     Q_PROPERTY(QObject *exitAnimation READ exitAnimation WRITE setExitAnimation NOTIFY exitAnimationChanged)
+    Q_PROPERTY(SceneAnchorItem *anchorItem READ anchorItem NOTIFY anchorItemChanged)
 public:
     explicit Scene(QQuickItem *parent = nullptr);
     virtual ~Scene() override = default;
@@ -119,6 +133,8 @@ public:
     QObject *exitAnimation() const;
     void setExitAnimation(QObject *animation);
 
+    SceneAnchorItem *anchorItem() const;
+
     void componentComplete() override;
 signals:
     void runningChanged();
@@ -127,6 +143,7 @@ signals:
     void debugChanged();
     void physicsChanged();
     void gameChanged();
+    void anchorItemChanged();
 
     /* These are wrapped around Box2DWorld */
     void initialized();
@@ -152,6 +169,7 @@ protected:
     Box2DDebugDraw *m_debugDraw;
     bool m_physics;
     bool m_debug;
+    SceneAnchorItem *m_sceneAnchorItem;
 
     QObject *m_enterAnimation;
     QObject *m_exitAnimation;

--- a/src/tmx/tmxtile.h
+++ b/src/tmx/tmxtile.h
@@ -60,7 +60,6 @@ public:
     int id() const { return m_tile->id(); }
 private:
     Tiled::Tile *m_tile;
-    TMXMap *m_map;
 };
 
 #endif // TMXTILE

--- a/src/tmx/tmxtileset.h
+++ b/src/tmx/tmxtileset.h
@@ -77,7 +77,6 @@ public:
     bool loadFromImage(const QString &fileName) { return m_tileset->loadFromImage(fileName); }
 private:
     Tiled::Tileset *m_tileset;
-    TMXMap *m_map;
 };
 
 #endif // TMXTILESET


### PR DESCRIPTION
- Using SceneAnchorItem, you can easily position QQuickItems on a game
scene
- Fix warnings of unused variables